### PR TITLE
Explicitly set benchmark target count,

### DIFF
--- a/test/Serilog.Formatting.Compact.Tests/FormattingBenchmarks.cs
+++ b/test/Serilog.Formatting.Compact.Tests/FormattingBenchmarks.cs
@@ -7,6 +7,7 @@ using Serilog.Formatting.Json;
 
 namespace Serilog.Formatting.Compact.Tests
 {
+    [Config(typeof(FormattingBenchmarksConfig))]
     public class FormattingBenchmarks
     {
         readonly LogEvent _evt;

--- a/test/Serilog.Formatting.Compact.Tests/FormattingBenchmarksConfig.cs
+++ b/test/Serilog.Formatting.Compact.Tests/FormattingBenchmarksConfig.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Jobs;
+
+namespace Serilog.Formatting.Compact.Tests
+{
+    public class FormattingBenchmarksConfig : ManualConfig
+    {
+        public FormattingBenchmarksConfig()
+        {
+            this.Add(Job.Default.WithTargetCount(new Count(10)));
+        }
+    }
+}


### PR DESCRIPTION
to avoid the situation where the build takes too long.
