### PR TITLE
Clarify semantics of `@r`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The format defines a handful of reified properties that have special meaning:
 | `@l` | Level | An implementation-specific level identifier (string or number) | Absence implies "informational"  |
 | `@x` | Exception | A language-dependent error representation potentially including backtrace | |
 | `@i` | Event id | An implementation specific event id (string or number) | |
-| `@r` | Renderings | If `@mt` includes properties with programming-language-specific formatting, an array of pre-rendered values for each such property | |
+| `@r` | Renderings | If `@mt` includes tokens with programming-language-specific formatting, an array of pre-rendered values for each such token | May be omitted; if present, the count of renderings must match the count of formatted tokens exactly |
 
 The `@` sigil may be escaped at the start of a user property name by doubling, e.g. `@@name` denotes a property called `@name`.
 


### PR DESCRIPTION
The `@r` property should always match the formatted tokens in the corresponding `@mt`.

As message templates can sometimes be mismatched or malformed in various ways, it was unclear what content should appear in `@r` in the case that exact one-for-one renderings can't be produced.

Omitting the field entirely is the simplest/cleanest option in this case, so I've updated the description of `@r` to accommodate this.