### PR TITLE
Bump Serilog version dependency to support Unity and .netstandard 2.0+

### DIFF
--- a/src/Serilog.Formatting.Compact/Serilog.Formatting.Compact.csproj
+++ b/src/Serilog.Formatting.Compact/Serilog.Formatting.Compact.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">


### PR DESCRIPTION
Same problem as this

https://github.com/serilog/serilog-extensions-logging/pull/188