### PR TITLE
Fix/issue 55 Supply IFormatProvider to CompactJsonFormatter/RenderedCompactJsonFormatter

### DIFF
--- a/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
@@ -29,6 +29,7 @@ namespace Serilog.Formatting.Compact;
 public class CompactJsonFormatter: ITextFormatter
 {
     readonly JsonValueFormatter _valueFormatter;
+    readonly IFormatProvider? _formatProvider;
 
     /// <summary>
     /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
@@ -41,13 +42,25 @@ public class CompactJsonFormatter: ITextFormatter
     }
 
     /// <summary>
+    /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
+    /// <see cref="LogEventPropertyValue"/>s on the event, and a format provider.
+    /// </summary>
+    /// <param name="valueFormatter">A value formatter, or null.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    public CompactJsonFormatter(JsonValueFormatter? valueFormatter, IFormatProvider? formatProvider)
+    {
+        _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
+        _formatProvider = formatProvider;
+    }
+
+    /// <summary>
     /// Format the log event into the output. Subsequent events will be newline-delimited.
     /// </summary>
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     public void Format(LogEvent logEvent, TextWriter output)
     {
-        FormatEvent(logEvent, output, _valueFormatter);
+        FormatEvent(logEvent, output, _valueFormatter, _formatProvider);
         output.WriteLine();
     }
 
@@ -58,6 +71,18 @@ public class CompactJsonFormatter: ITextFormatter
     /// <param name="output">The output.</param>
     /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
     public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter)
+    {
+        FormatEvent(logEvent, output, valueFormatter, null);
+    }
+
+    /// <summary>
+    /// Format the log event into the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter, IFormatProvider? formatProvider)
     {
         if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
         if (output == null) throw new ArgumentNullException(nameof(output));
@@ -84,7 +109,7 @@ public class CompactJsonFormatter: ITextFormatter
                 output.Write(delim);
                 delim = ",";
                 var space = new StringWriter();
-                r.Render(logEvent.Properties, space, CultureInfo.InvariantCulture);
+                r.Render(logEvent.Properties, space, formatProvider);
                 JsonValueFormatter.WriteQuotedJsonString(space.ToString(), output);
             }
             output.Write(']');

--- a/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
@@ -46,7 +46,7 @@ public class CompactJsonFormatter: ITextFormatter
     /// <see cref="LogEventPropertyValue"/>s on the event, and a format provider.
     /// </summary>
     /// <param name="valueFormatter">A value formatter, or null.</param>
-    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables. If null, defaults to <see cref="CultureInfo.InvariantCulture"/>.</param>
     public CompactJsonFormatter(JsonValueFormatter? valueFormatter, IFormatProvider? formatProvider)
     {
         _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
@@ -81,7 +81,7 @@ public class CompactJsonFormatter: ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
-    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables. If null, defaults to <see cref="CultureInfo.InvariantCulture"/>.</param>
     public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter, IFormatProvider? formatProvider)
     {
         if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));

--- a/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
@@ -109,7 +109,7 @@ public class CompactJsonFormatter: ITextFormatter
                 output.Write(delim);
                 delim = ",";
                 var space = new StringWriter();
-                r.Render(logEvent.Properties, space, formatProvider);
+                r.Render(logEvent.Properties, space, formatProvider ?? CultureInfo.InvariantCulture);
                 JsonValueFormatter.WriteQuotedJsonString(space.ToString(), output);
             }
             output.Write(']');

--- a/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/CompactJsonFormatter.cs
@@ -44,6 +44,7 @@ public class CompactJsonFormatter: ITextFormatter
     /// <summary>
     /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
     /// <see cref="LogEventPropertyValue"/>s on the event, and a format provider.
+    /// By default, message variables are rendered using <see cref="CultureInfo.InvariantCulture"/> if no provider is specified.
     /// </summary>
     /// <param name="valueFormatter">A value formatter, or null.</param>
     /// <param name="formatProvider">A format provider to apply when rendering message variables. If null, defaults to <see cref="CultureInfo.InvariantCulture"/>.</param>
@@ -77,6 +78,7 @@ public class CompactJsonFormatter: ITextFormatter
 
     /// <summary>
     /// Format the log event into the output.
+    /// By default, message variables are rendered using <see cref="CultureInfo.InvariantCulture"/> if no provider is specified.
     /// </summary>
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>

--- a/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
@@ -43,6 +43,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
     /// <summary>
     /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
     /// <see cref="LogEventPropertyValue"/>s on the event, and a format provider.
+    /// By default, message templates are rendered using <see cref="CultureInfo.InvariantCulture"/> if no provider is specified.
     /// </summary>
     /// <param name="valueFormatter">A value formatter, or null.</param>
     /// <param name="formatProvider">A format provider to apply when rendering message variables. If null, defaults to <see cref="CultureInfo.InvariantCulture"/>.</param>
@@ -76,6 +77,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
 
     /// <summary>
     /// Format the log event into the output.
+    /// By default, message templates are rendered using <see cref="CultureInfo.InvariantCulture"/> if no provider is specified.
     /// </summary>
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>

--- a/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
@@ -90,7 +90,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
         output.Write("{\"@t\":\"");
         output.Write(logEvent.Timestamp.UtcDateTime.ToString("O"));
         output.Write("\",\"@m\":");
-        var message = logEvent.MessageTemplate.Render(logEvent.Properties, formatProvider);
+        var message = logEvent.MessageTemplate.Render(logEvent.Properties, formatProvider ?? CultureInfo.InvariantCulture);
         JsonValueFormatter.WriteQuotedJsonString(message, output);
         output.Write(",\"@i\":\"");
         var id = EventIdHash.Compute(logEvent.MessageTemplate.Text);

--- a/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
@@ -31,7 +31,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
     readonly IFormatProvider? _formatProvider;
 
     /// <summary>
-    /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
+    /// Construct a <see cref="RenderedCompactJsonFormatter"/>, optionally supplying a formatter for
     /// <see cref="LogEventPropertyValue"/>s on the event.
     /// </summary>
     /// <param name="valueFormatter">A value formatter, or null.</param>

--- a/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
@@ -45,7 +45,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
     /// <see cref="LogEventPropertyValue"/>s on the event, and a format provider.
     /// </summary>
     /// <param name="valueFormatter">A value formatter, or null.</param>
-    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables. If null, defaults to <see cref="CultureInfo.InvariantCulture"/>.</param>
     public RenderedCompactJsonFormatter(JsonValueFormatter? valueFormatter, IFormatProvider? formatProvider)
     {
         _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
@@ -80,7 +80,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
-    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables. If null, defaults to <see cref="CultureInfo.InvariantCulture"/>.</param>
     public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter, IFormatProvider? formatProvider)
     {
         if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));

--- a/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
+++ b/src/Serilog.Formatting.Compact/RenderedCompactJsonFormatter.cs
@@ -28,6 +28,7 @@ namespace Serilog.Formatting.Compact;
 public class RenderedCompactJsonFormatter : ITextFormatter
 {
     readonly JsonValueFormatter _valueFormatter;
+    readonly IFormatProvider? _formatProvider;
 
     /// <summary>
     /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
@@ -40,13 +41,25 @@ public class RenderedCompactJsonFormatter : ITextFormatter
     }
 
     /// <summary>
+    /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
+    /// <see cref="LogEventPropertyValue"/>s on the event, and a format provider.
+    /// </summary>
+    /// <param name="valueFormatter">A value formatter, or null.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    public RenderedCompactJsonFormatter(JsonValueFormatter? valueFormatter, IFormatProvider? formatProvider)
+    {
+        _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
+        _formatProvider = formatProvider;
+    }
+
+    /// <summary>
     /// Format the log event into the output. Subsequent events will be newline-delimited.
     /// </summary>
     /// <param name="logEvent">The event to format.</param>
     /// <param name="output">The output.</param>
     public void Format(LogEvent logEvent, TextWriter output)
     {
-        FormatEvent(logEvent, output, _valueFormatter);
+        FormatEvent(logEvent, output, _valueFormatter, _formatProvider);
         output.WriteLine();
     }
 
@@ -58,6 +71,18 @@ public class RenderedCompactJsonFormatter : ITextFormatter
     /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
     public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter)
     {
+        FormatEvent(logEvent, output, valueFormatter, null);
+    }
+
+    /// <summary>
+    /// Format the log event into the output.
+    /// </summary>
+    /// <param name="logEvent">The event to format.</param>
+    /// <param name="output">The output.</param>
+    /// <param name="valueFormatter">A value formatter for <see cref="LogEventPropertyValue"/>s on the event.</param>
+    /// <param name="formatProvider">A format provider to apply when rendering message variables, or null.</param>
+    public static void FormatEvent(LogEvent logEvent, TextWriter output, JsonValueFormatter valueFormatter, IFormatProvider? formatProvider)
+    {
         if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
         if (output == null) throw new ArgumentNullException(nameof(output));
         if (valueFormatter == null) throw new ArgumentNullException(nameof(valueFormatter));
@@ -65,7 +90,7 @@ public class RenderedCompactJsonFormatter : ITextFormatter
         output.Write("{\"@t\":\"");
         output.Write(logEvent.Timestamp.UtcDateTime.ToString("O"));
         output.Write("\",\"@m\":");
-        var message = logEvent.MessageTemplate.Render(logEvent.Properties, CultureInfo.InvariantCulture);
+        var message = logEvent.MessageTemplate.Render(logEvent.Properties, formatProvider);
         JsonValueFormatter.WriteQuotedJsonString(message, output);
         output.Write(",\"@i\":\"");
         var id = EventIdHash.Compute(logEvent.MessageTemplate.Text);

--- a/test/Serilog.Formatting.Compact.Tests/CompactJsonFormatterTests.cs
+++ b/test/Serilog.Formatting.Compact.Tests/CompactJsonFormatterTests.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Diagnostics;
-using System.Linq;
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using Serilog.Events;
-using Xunit;
 using Serilog.Formatting.Compact.Tests.Support;
 using Serilog.Parsing;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Xunit;
 
 
 namespace Serilog.Formatting.Compact.Tests
@@ -93,6 +94,35 @@ namespace Serilog.Formatting.Compact.Tests
             var json = AssertValidJson(log => log.Write(evt));
             Assert.Equal(traceId.ToHexString(), json["@tr"]);
             Assert.Equal(spanId.ToHexString(), json["@sp"]);
+        }
+
+        [Fact]
+        public void RespectsCustomFormatProviderForRenderingsArray()
+        {
+            var frenchCulture = new CultureInfo("fr-FR");
+            var formatter = new CompactJsonFormatter(null, frenchCulture);
+
+            var jobject = Assertions.AssertValidJson(formatter, log => log.Information("Total: {Money:0.00}", 1.23));
+
+            JToken r;
+            Assert.True(jobject.TryGetValue("@r", out r));
+            var renderings = r.ToObject<string[]>();
+
+            Assert.Contains("1,23", renderings);
+        }
+
+        [Fact]
+        public void DefaultsToInvariantCultureWhenFormatProviderIsNull()
+        {
+            var formatter = new CompactJsonFormatter(null, null);
+
+            var jobject = Assertions.AssertValidJson(formatter, log => log.Information("Total: {Money:0.00}", 1.23));
+
+            JToken r;
+            Assert.True(jobject.TryGetValue("@r", out r));
+            var renderings = r.ToObject<string[]>();
+
+            Assert.Contains("1.23", renderings);
         }
     }
 }

--- a/test/Serilog.Formatting.Compact.Tests/RenderedCompactJsonFormatterTests.cs
+++ b/test/Serilog.Formatting.Compact.Tests/RenderedCompactJsonFormatterTests.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using Newtonsoft.Json.Linq;
-using Xunit;
+﻿using Newtonsoft.Json.Linq;
 using Serilog.Formatting.Compact.Tests.Support;
+using System;
+using System.Globalization;
+using Xunit;
 
 
 namespace Serilog.Formatting.Compact.Tests
@@ -74,6 +75,34 @@ namespace Serilog.Formatting.Compact.Tests
             JToken val;
             Assert.True(jobject.TryGetValue("@@Mistake", out val));
             Assert.Equal(42, val.ToObject<int>());
+        }
+
+        [Fact]
+        public void RespectsCustomFormatProviderForMessageRendering()
+        {
+            var frenchCulture = new CultureInfo("fr-FR");
+            var formatter = new RenderedCompactJsonFormatter(null, frenchCulture);
+
+            var jobject = Assertions.AssertValidJson(formatter, log => log.Information("Total: {Money:0.00}", 1.23));
+
+            JToken m;
+            Assert.True(jobject.TryGetValue("@m", out m));
+
+            Assert.Equal("Total: 1,23", m.ToObject<string>());
+        }
+
+        [Fact]
+        public void DefaultsToInvariantCultureWhenFormatProviderIsNull()
+        {
+            var formatter = new RenderedCompactJsonFormatter(null, null);
+
+            var jobject = Assertions.AssertValidJson(formatter, log => log.Information("Total: {Money:0.00}", 1.23));
+
+            JToken m;
+            Assert.True(jobject.TryGetValue("@m", out m));
+
+            // Should stay invariant (period) to match the v2 default
+            Assert.Equal("Total: 1.23", m.ToObject<string>());
         }
     }
 }


### PR DESCRIPTION
Fixes #55.

This PR introduces the ability for consumers to opt into the locale of their choosing when rendering message templates, addressing the issue raised where formatting was hardcoded to `CultureInfo.InvariantCulture` in #54.

**Changes included:**
* Added a new constructor overload to `CompactJsonFormatter` and `RenderedCompactJsonFormatter` that accepts an optional `IFormatProvider`.
* Added a new overload to the static `FormatEvent` methods in both classes to accept the `IFormatProvider`.
* Updated the `Render` calls to use the injected `IFormatProvider` (which will naturally fall back to the default culture if `null` is passed, restoring the original legacy behavior).
* **Binary compatibility maintained:** The existing constructors and 3-parameter static methods were left intact to ensure no breaking changes for currently compiled consumers. 
* *Bonus:* Fixed a minor XML documentation typo in `RenderedCompactJsonFormatter` constructors.

Tested locally to ensure everything works as expected. Let me know if any further tweaks are needed!